### PR TITLE
Cap Readwise imports at 10,000 articles and show truncation notice

### DIFF
--- a/src/routes/api/import/readwise/+server.ts
+++ b/src/routes/api/import/readwise/+server.ts
@@ -9,6 +9,7 @@ import type { RequestHandler } from './$types';
 
 const CONCURRENCY = 5;
 const JOB_TTL_MS = 5 * 60 * 1000;
+const IMPORT_LIMIT = 10_000;
 // Minimum gap between consecutive fetches to the same hostname. Prevents a
 // CSV heavy on one domain (e.g. 500 Medium articles) from burning the shared
 // Fly.io IP and triggering a ban that affects all users.
@@ -22,6 +23,8 @@ interface ImportJob {
 	done: boolean;
 	error: string | null;
 	completedAt: number | null;
+	truncated: boolean;
+	totalInFile: number;
 }
 
 const importJobs = new Map<string, ImportJob>();
@@ -226,6 +229,8 @@ export const GET: RequestHandler = async ({ locals }) => {
 		skipped: job.skipped,
 		done: job.done,
 		error: job.error,
+		truncated: job.truncated,
+		totalInFile: job.totalInFile,
 	});
 };
 
@@ -258,26 +263,30 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	};
 
 	const dataRows = rows.slice(1).filter(r => (r[idx.url] ?? '').trim().length > 0);
-	const total = dataRows.length;
+	const totalInFile = dataRows.length;
+	const truncated = totalInFile > IMPORT_LIMIT;
+	const limitedRows = truncated ? dataRows.slice(0, IMPORT_LIMIT) : dataRows;
 
 	const job: ImportJob = {
-		total,
+		total: limitedRows.length,
 		progress: 0,
 		imported: 0,
 		skipped: 0,
 		done: false,
 		error: null,
 		completedAt: null,
+		truncated,
+		totalInFile,
 	};
 	importJobs.set(locals.user.id, job);
 
 	// Fire and forget — runs after response is sent
-	runImport(job, dataRows, idx, locals.user.id, locals.user.region).catch(e => {
+	runImport(job, limitedRows, idx, locals.user.id, locals.user.region).catch(e => {
 		console.error('Readwise import failed:', e);
 		job.error = e.message;
 		job.done = true;
 		job.completedAt = Date.now();
 	});
 
-	return json({ total });
+	return json({ total: limitedRows.length, truncated, totalInFile });
 };

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -24,6 +24,8 @@
 	let importLoading = $state(false);
 	let importProgress = $state(0);
 	let importTotal = $state(0);
+	let importTruncated = $state(false);
+	let importTotalInFile = $state(0);
 	let importResult = $state<{ imported: number; skipped: number } | null>(null);
 	let importError = $state<string | null>(null);
 	let dragOver = $state(false);
@@ -105,6 +107,8 @@
 			const data = await res.json();
 			if (data.total !== undefined) importTotal = data.total;
 			if (data.progress !== undefined) importProgress = data.progress;
+			if (data.truncated !== undefined) importTruncated = data.truncated;
+			if (data.totalInFile !== undefined) importTotalInFile = data.totalInFile;
 			if (data.done) {
 				importResult = { imported: data.imported, skipped: data.skipped };
 				importLoading = false;
@@ -124,9 +128,13 @@
 			importLoading = true;
 			importTotal = data.total ?? 0;
 			importProgress = data.progress ?? 0;
+			importTruncated = data.truncated ?? false;
+			importTotalInFile = data.totalInFile ?? 0;
 			startPolling();
 		} else if (data.done) {
 			importResult = { imported: data.imported, skipped: data.skipped };
+			importTruncated = data.truncated ?? false;
+			importTotalInFile = data.totalInFile ?? 0;
 		}
 	});
 
@@ -149,6 +157,8 @@
 			}
 			const data = await res.json();
 			importTotal = data.total ?? 0;
+			importTruncated = data.truncated ?? false;
+			importTotalInFile = data.totalInFile ?? 0;
 			importFile = null;
 			if (fileInputEl) fileInputEl.value = '';
 			startPolling();
@@ -285,6 +295,9 @@
 			{#if importResult}
 				<p class="import-done">
 					Imported {importResult.imported} article{importResult.imported !== 1 ? 's' : ''}{importResult.skipped > 0 ? ` · ${importResult.skipped} already existed` : ''}.
+					{#if importTruncated}
+						Your file had {importTotalInFile.toLocaleString()} articles — upload the remaining {(importTotalInFile - 10000).toLocaleString()} separately to include them.
+					{/if}
 				</p>
 				<a href="/" class="btn" style="margin-top: 0.75rem;">Go to library</a>
 			{:else}
@@ -338,6 +351,9 @@
 						{/if}
 					</p>
 					<p class="leave-hint">You can safely leave this page — the import continues in the background.</p>
+					{#if importTruncated}
+						<p class="import-truncated">Your file contains {importTotalInFile.toLocaleString()} articles. Only the first 10,000 are being imported. Upload the remaining articles in a separate import to include them.</p>
+					{/if}
 				{/if}
 
 				{#if importError}
@@ -623,6 +639,12 @@
 		font-size: 0.8125rem;
 		color: var(--color-success);
 		margin: 0;
+	}
+
+	.import-truncated {
+		font-size: 0.8125rem;
+		color: var(--color-muted);
+		margin: 0 0 0.75rem;
 	}
 
 	/* Bookmarklet / install */


### PR DESCRIPTION
## Summary

- Adds `IMPORT_LIMIT = 10_000` constant in the Readwise import server route
- Slices `dataRows` before constructing the import job so only the first 10k rows are processed (Readwise exports are ordered most-recent-first, so recent saves are preserved)
- Tracks `truncated` and `totalInFile` on the `ImportJob` object and returns both fields in GET and POST responses
- Shows a warning notice during the import and in the completion message when the file exceeded the limit

## Test plan

- [ ] Upload a Readwise CSV with ≤ 10,000 rows — import proceeds normally, no truncation notice shown
- [ ] Upload a CSV with > 10,000 rows — only 10k articles are imported; truncation notice appears during progress and in the completion message with correct counts
- [ ] Refresh the settings page mid-import — truncation state is restored from the GET response and notice remains visible

Closes #5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBYutimhe3MfQNzQV7ndvn)_